### PR TITLE
ELIMINATE RECURSIONERROR IN GALLERY SERIALIZERS

### DIFF
--- a/app/photos/serializers.py
+++ b/app/photos/serializers.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 from app.photos.models import Album, Photo
-from app.user.serializers import ProfileSerializer
 
 class PhotoSerializer(serializers.ModelSerializer):
     album = serializers.PrimaryKeyRelatedField(queryset=Album.objects.all())  # Handle UUID lookup
@@ -12,15 +11,10 @@ class PhotoSerializer(serializers.ModelSerializer):
 class AlbumSerializer(serializers.ModelSerializer):
     user = serializers.UUIDField(read_only=True, source='user.id')
     photos = PhotoSerializer(many=True, read_only=True)
-    profile = serializers.SerializerMethodField()
 
     class Meta:
         model = Album
-        fields = ['id', 'user', 'title', 'photos', 'profile']
-
-    def get_profile(self, obj):
-        profile = obj.user.profile
-        return ProfileSerializer(profile, context=self.context).data
+        fields = ['id', 'user', 'title', 'photos']
 
     def create(self, validated_data):
         validated_data['user'] = self.context['request'].user


### PR DESCRIPTION
- Removed `profile` from `AlbumSerializer` to prevent circular reference with `ProfileSerializer`

-  Ensures albums and photos are only nested in profile endpoint, not recursively

![Screenshot from 2025-04-07 12-58-04](https://github.com/user-attachments/assets/28168a84-ed7c-4876-a13b-ff3b560609cc)
![Screenshot from 2025-04-07 12-59-21](https://github.com/user-attachments/assets/b82ab646-7459-4c03-b8d4-d3de996464e8)
